### PR TITLE
Minor fixes to schemas

### DIFF
--- a/CIP-0116/cardano-babbage.json
+++ b/CIP-0116/cardano-babbage.json
@@ -146,7 +146,7 @@
             "tag",
             "value"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -164,7 +164,7 @@
             "tag",
             "value"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         }
       ]
     },
@@ -180,10 +180,10 @@
               "$ref": "cardano-babbage.json#/definitions/PosInt64"
             }
           },
-          "additionalProperties": false
+          "unevaluatedProperties": false
         }
       },
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "Value": {
       "title": "Value",
@@ -199,7 +199,7 @@
       "required": [
         "coin"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "TransactionHash": {
       "title": "TransactionHash",
@@ -224,7 +224,7 @@
         "transaction_id",
         "index"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "PlutusScript": {
       "title": "PlutusScript",
@@ -243,7 +243,7 @@
         "language",
         "bytes"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "NativeScript": {
       "title": "NativeScript",
@@ -266,7 +266,7 @@
               "$ref": "cardano-babbage.json#/definitions/Ed25519KeyHash"
             }
           },
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "required": [
             "tag",
             "pubkey"
@@ -289,7 +289,7 @@
               }
             }
           },
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "required": [
             "tag",
             "scripts"
@@ -312,7 +312,7 @@
               }
             }
           },
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "required": [
             "tag",
             "scripts"
@@ -338,7 +338,7 @@
               "$ref": "cardano-babbage.json#/definitions/UInt32"
             }
           },
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "required": [
             "tag",
             "scripts",
@@ -359,7 +359,7 @@
               "$ref": "cardano-babbage.json#/definitions/UInt64"
             }
           },
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "required": [
             "tag",
             "slot"
@@ -379,7 +379,7 @@
               "$ref": "cardano-babbage.json#/definitions/UInt64"
             }
           },
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "required": [
             "tag",
             "slot"
@@ -412,7 +412,7 @@
             "tag",
             "value"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "title": "NativeScript",
@@ -432,7 +432,7 @@
             "tag",
             "value"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         }
       ]
     },
@@ -510,7 +510,7 @@
         "input",
         "output"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "TransactionMetadatum": {
       "title": "TransactionMetadatum",
@@ -543,7 +543,7 @@
                   "key",
                   "value"
                 ],
-                "additionalProperties": false
+                "unevaluatedProperties": false
               }
             }
           },
@@ -551,7 +551,7 @@
             "tag",
             "contents"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -572,7 +572,7 @@
             "tag",
             "contents"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -590,7 +590,7 @@
             "tag",
             "value"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -610,7 +610,7 @@
             "tag",
             "value"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "title": "Metadata String",
@@ -632,7 +632,7 @@
             "tag",
             "value"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         }
       ]
     },
@@ -666,7 +666,7 @@
         }
       },
       "required": [],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "ExUnitPrices": {
       "title": "ExUnitPrices",
@@ -679,7 +679,7 @@
           "$ref": "cardano-babbage.json#/definitions/UnitInterval"
         }
       },
-      "additionalProperties": false,
+      "unevaluatedProperties": false,
       "required": [
         "mem_price",
         "step_price"
@@ -700,7 +700,7 @@
         "mem",
         "steps"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "ProtocolVersion": {
       "title": "ProtocolVersion",
@@ -717,7 +717,7 @@
         "major",
         "minor"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "ProtocolParamUpdate": {
       "title": "ProtocolParamUpdate",
@@ -793,7 +793,7 @@
           "$ref": "cardano-babbage.json#/definitions/UnitInterval"
         }
       },
-      "additionalProperties": false,
+      "unevaluatedProperties": false,
       "required": []
     },
     "Update": {
@@ -813,14 +813,14 @@
               "$ref": "cardano-babbage.json#/definitions/ProtocolParamUpdate"
             }
           },
-          "additionalProperties": false
+          "unevaluatedProperties": false
         }
       },
       "required": [
         "epoch",
         "proposed_protocol_parameter_updates"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "ScriptDataHash": {
       "title": "ScriptDataHash",
@@ -845,7 +845,7 @@
           "key",
           "value"
         ],
-        "additionalProperties": false
+        "unevaluatedProperties": false
       }
     },
     "AuxiliaryDataHash": {
@@ -875,7 +875,7 @@
         }
       },
       "required": [],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "TransactionBody": {
       "title": "TransactionBody",
@@ -969,7 +969,7 @@
                 "$ref": "cardano-babbage.json#/definitions/UInt64"
               }
             },
-            "additionalProperties": false
+            "unevaluatedProperties": false
           }
         }
       },
@@ -978,7 +978,7 @@
         "outputs",
         "fee"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "NetworkId": {
       "title": "NetworkId",
@@ -1012,7 +1012,7 @@
             }
           },
           "required": ["tag", "contents"],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "title": "PlutusDataConstr",
@@ -1034,7 +1034,7 @@
             }
           },
           "required": ["tag", "alternative", "data"],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "title": "PlutusDataMap",
@@ -1057,12 +1057,12 @@
                     "$ref": "cardano-babbage.json#/definitions/PlutusData"
                   }
                 },
-                "additionalProperties": false
+                "unevaluatedProperties": false
               }
             }
           },
           "required": ["tag", "contents"],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "title": "PlutusDataInteger",
@@ -1079,7 +1079,7 @@
             }
           },
           "required": ["tag", "value"],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "title": "PlutusDataBytes",
@@ -1097,7 +1097,7 @@
             }
           },
           "required": ["tag", "value"],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         }
       ]
     },
@@ -1113,7 +1113,7 @@
         }
       },
       "required": ["numerator", "denominator"],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "Ipv4": {
       "title": "Ipv4",
@@ -1163,7 +1163,7 @@
           "required": [
             "tag"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -1183,7 +1183,7 @@
               "$ref": "cardano-babbage.json#/definitions/DNSName"
             }
           },
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "required": [
             "tag",
             "dns_name"
@@ -1202,7 +1202,7 @@
               "$ref": "cardano-babbage.json#/definitions/DNSName"
             }
           },
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "required": [
             "tag",
             "dns_name"
@@ -1242,7 +1242,7 @@
           "$ref": "cardano-babbage.json#/definitions/PoolMetadataHash"
         }
       },
-      "additionalProperties": false,
+      "unevaluatedProperties": false,
       "required": [
         "url",
         "hash"
@@ -1302,7 +1302,7 @@
         "reward_account",
         "vrf_keyhash"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "GenesisHash": {
       "title": "GenesisHash",
@@ -1360,11 +1360,11 @@
                   "key",
                   "value"
                 ],
-                "additionalProperties": false
+                "unevaluatedProperties": false
               }
             }
           },
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "required": [
             "pot",
             "rewards"
@@ -1386,7 +1386,7 @@
               "$ref": "cardano-babbage.json#/definitions/UInt64"
             }
           },
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "required": [
             "pot",
             "amount"
@@ -1418,7 +1418,7 @@
             "tag",
             "credential"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -1437,7 +1437,7 @@
             "tag",
             "credential"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -1460,7 +1460,7 @@
             "credential",
             "pool_keyhash"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -1479,7 +1479,7 @@
             "tag",
             "pool_params"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -1503,7 +1503,7 @@
             "pool_keyhash",
             "epoch"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -1531,7 +1531,7 @@
             "genesis_delegate_hash",
             "vrf_keyhash"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -1550,7 +1550,7 @@
             "tag",
             "move_instantaneous_rewards"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         }
       ]
     },
@@ -1589,7 +1589,7 @@
                 "asset_name",
                 "amount"
               ],
-              "additionalProperties": false
+              "unevaluatedProperties": false
             }
           }
         },
@@ -1597,7 +1597,7 @@
           "script_hash",
           "assets"
         ],
-        "additionalProperties": false
+        "unevaluatedProperties": false
       }
     },
     "Ed25519Signature": {
@@ -1639,7 +1639,7 @@
         "signature",
         "vkey"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "RedeemerTag": {
       "title": "RedeemerTag",
@@ -1674,7 +1674,7 @@
         "index",
         "ex_units"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "Vkeywitness": {
       "title": "Vkeywitness",
@@ -1691,7 +1691,7 @@
         "vkey",
         "signature"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "TransactionWitnessSet": {
       "title": "TransactionWitnessSet",
@@ -1764,7 +1764,7 @@
         "is_valid",
         "witness_set"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "VRFCert": {
       "title": "VRFCert",
@@ -1783,7 +1783,7 @@
         "output",
         "proof"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "KESVKey": {
       "title": "KESVKey",
@@ -1840,7 +1840,7 @@
         "sequence_number",
         "sigma"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "HeaderBody": {
       "title": "HeaderBody",
@@ -1877,7 +1877,7 @@
           "$ref": "cardano-babbage.json#/definitions/ProtocolVersion"
         }
       },
-      "additionalProperties": false,
+      "unevaluatedProperties": false,
       "required": [
         "block_number",
         "slot",
@@ -1905,7 +1905,7 @@
         "body_signature",
         "header_body"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "Block": {
       "title": "Block",
@@ -1920,7 +1920,7 @@
               "$ref": "cardano-babbage.json#/definitions/AuxiliaryData"
             }
           },
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         "header": {
           "$ref": "cardano-babbage.json#/definitions/Header"
@@ -1951,7 +1951,7 @@
           }
         }
       },
-      "additionalProperties": false,
+      "unevaluatedProperties": false,
       "required": [
         "auxiliary_data_set",
         "header",

--- a/CIP-0116/cardano-babbage.json
+++ b/CIP-0116/cardano-babbage.json
@@ -1010,7 +1010,9 @@
                 "$ref": "cardano-babbage.json#/definitions/PlutusData"
               }
             }
-          }
+          },
+          "required": ["tag", "contents"],
+          "additionalProperties": false
         },
         {
           "title": "PlutusDataConstr",
@@ -1030,7 +1032,9 @@
                 "$ref": "cardano-babbage.json#/definitions/PlutusData"
               }
             }
-          }
+          },
+          "required": ["tag", "alternative", "data"],
+          "additionalProperties": false
         },
         {
           "title": "PlutusDataMap",
@@ -1052,10 +1056,13 @@
                   "value": {
                     "$ref": "cardano-babbage.json#/definitions/PlutusData"
                   }
-                }
+                },
+                "additionalProperties": false
               }
             }
-          }
+          },
+          "required": ["tag", "contents"],
+          "additionalProperties": false
         },
         {
           "title": "PlutusDataInteger",
@@ -1070,7 +1077,9 @@
             "value": {
               "$ref": "cardano-babbage.json#/definitions/BigInt"
             }
-          }
+          },
+          "required": ["tag", "value"],
+          "additionalProperties": false
         },
         {
           "title": "PlutusDataBytes",
@@ -1086,7 +1095,9 @@
               "format": "hex",
               "pattern": "^([0-9a-f][0-9a-f])*$"
             }
-          }
+          },
+          "required": ["tag", "value"],
+          "additionalProperties": false
         }
       ]
     },
@@ -1101,6 +1112,7 @@
           "$ref": "cardano-babbage.json#/definitions/UInt64"
         }
       },
+      "required": ["numerator", "denominator"],
       "additionalProperties": false
     },
     "Ipv4": {

--- a/CIP-0116/cardano-conway.json
+++ b/CIP-0116/cardano-conway.json
@@ -1224,7 +1224,9 @@
                 "$ref": "cardano-conway.json#/definitions/PlutusData"
               }
             }
-          }
+          },
+          "required": ["tag", "contents"],
+          "additionalProperties": false
         },
         {
           "title": "PlutusDataConstr",
@@ -1244,7 +1246,9 @@
                 "$ref": "cardano-conway.json#/definitions/PlutusData"
               }
             }
-          }
+          },
+          "required": ["tag", "alternative", "data"],
+          "additionalProperties": false
         },
         {
           "title": "PlutusDataMap",
@@ -1266,10 +1270,13 @@
                   "value": {
                     "$ref": "cardano-conway.json#/definitions/PlutusData"
                   }
-                }
+                },
+                "additionalProperties": false
               }
             }
-          }
+          },
+          "required": ["tag", "contents"],
+          "additionalProperties": false
         },
         {
           "title": "PlutusDataInteger",
@@ -1284,7 +1291,9 @@
             "value": {
               "$ref": "cardano-conway.json#/definitions/BigInt"
             }
-          }
+          },
+          "required": ["tag", "value"],
+          "additionalProperties": false
         },
         {
           "title": "PlutusDataBytes",
@@ -1300,7 +1309,9 @@
               "format": "hex",
               "pattern": "^([0-9a-f][0-9a-f])*$"
             }
-          }
+          },
+          "required": ["tag", "value"],
+          "additionalProperties": false
         }
       ]
     },
@@ -1315,6 +1326,7 @@
           "$ref": "cardano-conway.json#/definitions/UInt64"
         }
       },
+      "required": ["numerator", "denominator"],
       "additionalProperties": false
     },
     "Ipv4": {
@@ -1552,7 +1564,7 @@
               "$ref": "cardano-conway.json#/definitions/Ed25519KeyHash"
             }
           },
-          "required": ["tag", "keyhash"]
+          "required": ["tag", "key_hash"]
         },
         {
           "type": "object",
@@ -2170,7 +2182,7 @@
               "$ref": "cardano-conway.json#/definitions/ScriptHash"
             }
           },
-          "required": [ ]
+          "required": ["tag"]
         },
         {
           "type": "object",

--- a/CIP-0116/cardano-conway.json
+++ b/CIP-0116/cardano-conway.json
@@ -144,7 +144,7 @@
           "key",
           "value"
         ],
-        "additionalProperties": false
+        "unevaluatedProperties": false
       }
     },
     "AuxiliaryDataHash": {
@@ -154,7 +154,7 @@
       "pattern": "^[0-9a-f]{64}$"
     },
     "AuxiliaryData": {
-      "additionalProperties": false,
+      "unevaluatedProperties": false,
       "properties": {
         "metadata": {
           "$ref": "cardano-conway.json#/definitions/TransactionMetadata"
@@ -201,7 +201,7 @@
             }
           },
           "required": ["tag", "credential"],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -214,7 +214,7 @@
             }
           },
           "required": ["tag", "credential"],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -227,7 +227,7 @@
             }
           },
           "required": ["tag", "credential"],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         }
       ]
     },
@@ -243,7 +243,7 @@
         }
       },
       "required": ["vote"],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "VotingProcedures": {
       "title": "VotingProcedures",
@@ -270,7 +270,7 @@
                 "key",
                 "value"
               ],
-              "additionalProperties": false
+              "unevaluatedProperties": false
             }
           }
         },
@@ -278,7 +278,7 @@
           "key",
           "value"
         ],
-        "additionalProperties": false
+        "unevaluatedProperties": false
       }
     },
     "ProposalProcedure": {
@@ -299,7 +299,7 @@
         }
       },
       "required": [ "deposit", "reward_account", "gov_action", "anchor" ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "ProposalProcedures": {
       "title": "ProposalProcedures",
@@ -402,7 +402,7 @@
                 "$ref": "cardano-conway.json#/definitions/UInt64"
               }
             },
-            "additionalProperties": false
+            "unevaluatedProperties": false
           }
         },
         "voting_procedures": {
@@ -423,7 +423,7 @@
         "outputs",
         "fee"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "Credential": {
       "title": "Credential",
@@ -448,7 +448,7 @@
             "tag",
             "value"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -466,7 +466,7 @@
             "tag",
             "value"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         }
       ]
     },
@@ -482,10 +482,10 @@
               "$ref": "cardano-conway.json#/definitions/PosInt64"
             }
           },
-          "additionalProperties": false
+          "unevaluatedProperties": false
         }
       },
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "Value": {
       "title": "Value",
@@ -501,7 +501,7 @@
       "required": [
         "coin"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "TransactionHash": {
       "title": "TransactionHash",
@@ -526,7 +526,7 @@
         "transaction_id",
         "index"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "PlutusScript": {
       "title": "PlutusScript",
@@ -545,7 +545,7 @@
         "language",
         "bytes"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "NativeScript": {
       "title": "NativeScript",
@@ -568,7 +568,7 @@
               "$ref": "cardano-conway.json#/definitions/Ed25519KeyHash"
             }
           },
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "required": [
             "tag",
             "pubkey"
@@ -591,7 +591,7 @@
               }
             }
           },
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "required": [
             "tag",
             "scripts"
@@ -614,7 +614,7 @@
               }
             }
           },
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "required": [
             "tag",
             "scripts"
@@ -640,7 +640,7 @@
               "$ref": "cardano-conway.json#/definitions/UInt32"
             }
           },
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "required": [
             "tag",
             "scripts",
@@ -661,7 +661,7 @@
               "$ref": "cardano-conway.json#/definitions/UInt64"
             }
           },
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "required": [
             "tag",
             "slot"
@@ -681,7 +681,7 @@
               "$ref": "cardano-conway.json#/definitions/UInt64"
             }
           },
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "required": [
             "tag",
             "slot"
@@ -714,7 +714,7 @@
             "tag",
             "value"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "title": "NativeScript",
@@ -734,7 +734,7 @@
             "tag",
             "value"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         }
       ]
     },
@@ -812,7 +812,7 @@
         "input",
         "output"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "TransactionMetadatum": {
       "title": "TransactionMetadatum",
@@ -845,7 +845,7 @@
                   "key",
                   "value"
                 ],
-                "additionalProperties": false
+                "unevaluatedProperties": false
               }
             }
           },
@@ -853,7 +853,7 @@
             "tag",
             "contents"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -874,7 +874,7 @@
             "tag",
             "contents"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -892,7 +892,7 @@
             "tag",
             "value"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -912,7 +912,7 @@
             "tag",
             "value"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "title": "Metadata String",
@@ -934,7 +934,7 @@
             "tag",
             "value"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         }
       ]
     },
@@ -980,7 +980,7 @@
         }
       },
       "required": [],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "ExUnitPrices": {
       "title": "ExUnitPrices",
@@ -993,7 +993,7 @@
           "$ref": "cardano-conway.json#/definitions/UnitInterval"
         }
       },
-      "additionalProperties": false,
+      "unevaluatedProperties": false,
       "required": [
         "mem_price",
         "step_price"
@@ -1014,7 +1014,7 @@
         "mem",
         "steps"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "ProtocolVersion": {
       "title": "ProtocolVersion",
@@ -1031,7 +1031,7 @@
         "major",
         "minor"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "NonnegativeInterval": {
       "title": "NonnegativeInterval",
@@ -1044,7 +1044,7 @@
           "$ref": "cardano-conway.json#/definitions/PosInt64"
         }
       },
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "PoolVotingThresholds": {
       "title": "PoolVotingThresholds",
@@ -1165,7 +1165,7 @@
           "$ref": "cardano-conway.json#/definitions/NonnegativeInterval"
         }
       },
-      "additionalProperties": false,
+      "unevaluatedProperties": false,
       "required": []
     },
     "Update": {
@@ -1185,14 +1185,14 @@
               "$ref": "cardano-conway.json#/definitions/ProtocolParamUpdate"
             }
           },
-          "additionalProperties": false
+          "unevaluatedProperties": false
         }
       },
       "required": [
         "epoch",
         "proposed_protocol_parameter_updates"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "NetworkId": {
       "title": "NetworkId",
@@ -1226,7 +1226,7 @@
             }
           },
           "required": ["tag", "contents"],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "title": "PlutusDataConstr",
@@ -1248,7 +1248,7 @@
             }
           },
           "required": ["tag", "alternative", "data"],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "title": "PlutusDataMap",
@@ -1271,12 +1271,12 @@
                     "$ref": "cardano-conway.json#/definitions/PlutusData"
                   }
                 },
-                "additionalProperties": false
+                "unevaluatedProperties": false
               }
             }
           },
           "required": ["tag", "contents"],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "title": "PlutusDataInteger",
@@ -1293,7 +1293,7 @@
             }
           },
           "required": ["tag", "value"],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "title": "PlutusDataBytes",
@@ -1311,7 +1311,7 @@
             }
           },
           "required": ["tag", "value"],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         }
       ]
     },
@@ -1327,7 +1327,7 @@
         }
       },
       "required": ["numerator", "denominator"],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "Ipv4": {
       "title": "Ipv4",
@@ -1377,7 +1377,7 @@
           "required": [
             "tag"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -1397,7 +1397,7 @@
               "$ref": "cardano-conway.json#/definitions/DNSName"
             }
           },
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "required": [
             "tag",
             "dns_name"
@@ -1416,7 +1416,7 @@
               "$ref": "cardano-conway.json#/definitions/DNSName"
             }
           },
-          "additionalProperties": false,
+          "unevaluatedProperties": false,
           "required": [
             "tag",
             "dns_name"
@@ -1456,7 +1456,7 @@
           "$ref": "cardano-conway.json#/definitions/PoolMetadataHash"
         }
       },
-      "additionalProperties": false,
+      "unevaluatedProperties": false,
       "required": [
         "url",
         "hash"
@@ -1516,7 +1516,7 @@
         "reward_account",
         "vrf_keyhash"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "GenesisHash": {
       "title": "GenesisHash",
@@ -1545,7 +1545,7 @@
         "url",
         "data_hash"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "DRep": {
       "title": "DRep",
@@ -1622,7 +1622,7 @@
             "tag",
             "credential"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -1641,7 +1641,7 @@
             "tag",
             "credential"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -1664,7 +1664,7 @@
             "credential",
             "pool_keyhash"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -1683,7 +1683,7 @@
             "tag",
             "pool_params"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -1707,7 +1707,7 @@
             "pool_keyhash",
             "epoch"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -1731,7 +1731,7 @@
             "credential",
             "coin"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -1755,7 +1755,7 @@
             "credential",
             "coin"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -1779,7 +1779,7 @@
             "credential",
             "drep"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -1807,7 +1807,7 @@
             "pool_keyhash",
             "drep"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -1834,7 +1834,7 @@
             "pool_keyhash",
             "coin"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -1865,7 +1865,7 @@
             "drep",
             "coin"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -1893,7 +1893,7 @@
             "pool_keyhash",
             "drep"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -1921,7 +1921,7 @@
             "drep",
             "coin"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -1953,7 +1953,7 @@
             "drep",
             "coin"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -1977,7 +1977,7 @@
             "committee_cold_credential",
             "committee_hot_credential"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -2000,7 +2000,7 @@
             "committee_cold_credential",
             "tag"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -2027,7 +2027,7 @@
             "drep_credential",
             "coin"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -2051,7 +2051,7 @@
             "drep_credential",
             "coin"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         {
           "type": "object",
@@ -2074,7 +2074,7 @@
             "tag",
             "drep_credential"
           ],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         }
       ]
     },
@@ -2103,7 +2103,7 @@
         }
       },
       "required": ["transaction_id", "gov_action_index"],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "GovAction": {
       "title": "GovAction",
@@ -2175,7 +2175,7 @@
                     "$ref": "cardano-conway.json#/definitions/UInt64"
                   }
                 },
-                "additionalProperties": false
+                "unevaluatedProperties": false
               }
             },
             "policy_hash": {
@@ -2231,7 +2231,7 @@
                     "$ref": "cardano-conway.json#/definitions/UInt64"
                   }
                 },
-                "additionalProperties": false
+                "unevaluatedProperties": false
               }
             },
             "signature_threshold": {
@@ -2310,7 +2310,7 @@
                 "asset_name",
                 "amount"
               ],
-              "additionalProperties": false
+              "unevaluatedProperties": false
             }
           }
         },
@@ -2318,7 +2318,7 @@
           "script_hash",
           "assets"
         ],
-        "additionalProperties": false
+        "unevaluatedProperties": false
       }
     },
     "Ed25519Signature": {
@@ -2360,7 +2360,7 @@
         "signature",
         "vkey"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "RedeemerTag": {
       "title": "RedeemerTag",
@@ -2397,7 +2397,7 @@
         "index",
         "ex_units"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "Vkeywitness": {
       "title": "Vkeywitness",
@@ -2414,7 +2414,7 @@
         "vkey",
         "signature"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "TransactionWitnessSet": {
       "title": "TransactionWitnessSet",
@@ -2487,7 +2487,7 @@
         "is_valid",
         "witness_set"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "VRFCert": {
       "title": "VRFCert",
@@ -2506,7 +2506,7 @@
         "output",
         "proof"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "KESVKey": {
       "title": "KESVKey",
@@ -2563,7 +2563,7 @@
         "sequence_number",
         "sigma"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "HeaderBody": {
       "title": "HeaderBody",
@@ -2600,7 +2600,7 @@
           "$ref": "cardano-conway.json#/definitions/ProtocolVersion"
         }
       },
-      "additionalProperties": false,
+      "unevaluatedProperties": false,
       "required": [
         "block_number",
         "slot",
@@ -2628,7 +2628,7 @@
         "body_signature",
         "header_body"
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "Block": {
       "title": "Block",
@@ -2643,7 +2643,7 @@
               "$ref": "cardano-conway.json#/definitions/AuxiliaryData"
             }
           },
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         "header": {
           "$ref": "cardano-conway.json#/definitions/Header"
@@ -2674,7 +2674,7 @@
           }
         }
       },
-      "additionalProperties": false,
+      "unevaluatedProperties": false,
       "required": [
         "auxiliary_data_set",
         "header",

--- a/CIP-0116/cardano-conway.json
+++ b/CIP-0116/cardano-conway.json
@@ -1044,6 +1044,7 @@
           "$ref": "cardano-conway.json#/definitions/PosInt64"
         }
       },
+      "required": ["numerator", "denominator"],
       "unevaluatedProperties": false
     },
     "PoolVotingThresholds": {


### PR DESCRIPTION
Fixes:

- Add required fields to UnitInterval
- Add required fields to plutusData variants
- Add required tag to treasury_withdwls_action (Conway only)
- Fix `Ed25519KeyHash` required field (Conway only)
- Replace `additionalProperties` with `unevaluatedProperties`
- Add required fields to NonnegativeInterval (Conway only)